### PR TITLE
Update to latest Boot, SCS, and Spring Cloud

### DIFF
--- a/manifest-pcf.yml
+++ b/manifest-pcf.yml
@@ -2,7 +2,7 @@
 instances: 1
 applications:
 - name: fortune-service
-  memory: 512M
+  memory: 1024M
   host: fortunes
   path: fortune-teller-fortune-service/target/fortune-teller-fortune-service-0.0.1-SNAPSHOT.jar
   services:

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.7.RELEASE</version>
+        <version>1.4.4.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -60,14 +60,14 @@
             <dependency>
                 <groupId>io.pivotal.spring.cloud</groupId>
                 <artifactId>spring-cloud-services-dependencies</artifactId>
-                <version>1.2.0.RELEASE</version>
+                <version>1.4.1.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Brixton.SR6</version>
+                <version>Camden.SR4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This updates fortune-teller to Boot 1.4.4, SCS 1.4.1, and Spring Cloud Camden.SR4. Note that I failed to create a branch before performing this work, so that PR is from my master branch. (Should be fine.)