### PR TITLE
Updated scripts and dependencies to work with mysql v2 tile

### DIFF
--- a/fortune-teller-fortune-service/pom.xml
+++ b/fortune-teller-fortune-service/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<version>1.1.7</version>
+			<version>2.2.6</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.0.4.RELEASE</version>
 		<relativePath/>
 	</parent>
 

--- a/scripts/pcf-create-services.sh
+++ b/scripts/pcf-create-services.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cf cs p-mysql 100mb fortunes-db
-cf cs p-config-server standard config-server -c '{"git": { "uri": "https://github.com/spring-cloud-services-samples/fortune-teller", "searchPaths": "configuration" } }'
+cf cs p.mysql db-small fortunes-db
+cf cs p-config-server standard config-server -c '{"skipSslValidation": true, "git": { "uri": "https://github.com/spring-cloud-services-samples/fortune-teller", "searchPaths": "configuration" } }'
 cf cs p-service-registry standard service-registry
 cf cs p-circuit-breaker-dashboard standard circuit-breaker


### PR DESCRIPTION
Biggest fix here is updating the mariadb client to 2.2.6 which fixes the error:

```
sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```

Also updates the create script to use the new tile and plan names.