### PR TITLE
Upgrade starters to v3.0.1.RELEASE

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,11 +35,9 @@ Creating service config-server in org microservices / space fortune-teller as ad
 OK
 Creating service service-registry in org microservices / space fortune-teller as admin...
 OK
-Creating service circuit-breaker-dashboard in org microservices / space fortune-teller as admin...
-OK
 ----
 
-. Click on the *Manage* links for the *Config Service*, *Service Registry*, and *Circuit Breaker Dashboard*. Make sure the services are finished initializing before you proceed.
+. Click on the *Manage* links for the *Config Service* and *Service Registry*. Make sure the services are finished initializing before you proceed.
 
 . Edit the `manifest-pcf.yml` file to specify the Cloud Foundry target the apps are being pushed to, replacing the URL in `CF_TARGET: https://api.yourpcfenvironment.local` with the API endpoint for your Cloud Foundry deployment.
 
@@ -64,7 +62,7 @@ image:docs/images/fortunes_1.png[]
 $ cf stop fortune-service
 ----
 
-. Access the fortunes-ui and see that the ``fallback fortune'' is being returned.
+. Access the fortunes-ui and see that the default fortune is being returned.
 +
 image:docs/images/fortunes_4.png[]
 

--- a/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortuneService.java
+++ b/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortuneService.java
@@ -15,11 +15,15 @@
  */
  package io.spring.cloud.samples.fortuneteller.ui.services.fortunes;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 @Service
 public class FortuneService {
+    private Logger log = LoggerFactory.getLogger(FortuneService.class);
 
     private RestTemplate rest;
 
@@ -28,7 +32,11 @@ public class FortuneService {
     }
 
     public Fortune randomFortune() {
-        return rest.getForObject("http://fortunes/random", Fortune.class);
+        try {
+            return rest.getForObject("http://fortunes/random", Fortune.class);
+        } catch (RestClientException e) {
+            log.error("Failed to get fortune from fortune-service", e);
+            return new Fortune(42l, "Your future is unclear.");
+        }
     }
-
 }

--- a/manifest-pcf.yml
+++ b/manifest-pcf.yml
@@ -8,7 +8,9 @@ applications:
   - fortunes-db
   - config-server
   - service-registry
-  #env:
+  env:
+    # JBP adds deprecated connectors when using mysql service
+    JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{"enabled":false}'
     # Replace with API URI of target PCF environment
     #CF_TARGET: https://api.yourpcfenvironment.local
 - name: fortune-ui
@@ -18,6 +20,7 @@ applications:
   services:
   - config-server
   - service-registry
-  #env:
+  env:
     # Replace with API URI of target PCF environment
     #CF_TARGET: https://api.yourpcfenvironment.local
+

--- a/manifest-pws.yml
+++ b/manifest-pws.yml
@@ -17,4 +17,3 @@ applications:
   services:
   - fortunes-config-server
   - fortunes-service-registry
-  - fortunes-circuit-breaker-dashboard

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.8.RELEASE</version>
+		<version>2.1.10.RELEASE</version>
 		<relativePath/>
 	</parent>
 
@@ -55,14 +55,14 @@
 			<dependency>
 				<groupId>io.pivotal.spring.cloud</groupId>
 				<artifactId>spring-cloud-services-dependencies</artifactId>
-				<version>2.1.4.RELEASE</version>
+				<version>3.0.1.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Greenwich.SR3</version>
+				<version>Greenwich.SR4</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/scripts/pcf-undeploy.sh
+++ b/scripts/pcf-undeploy.sh
@@ -8,4 +8,3 @@ cf delete fortune-ui -f
 cf delete-service fortunes-db -f
 cf delete-service config-server -f
 cf delete-service service-registry -f
-cf delete-service circuit-breaker -f

--- a/scripts/pws-create-services.sh
+++ b/scripts/pws-create-services.sh
@@ -3,4 +3,3 @@
 cf create-service cleardb spark fortunes-db
 cf create-service p-config-server trial fortunes-config-server -c '{"git": { "uri": "https://github.com/spring-cloud-services-samples/fortune-teller", "searchPaths": "configuration" } }'
 cf create-service p-service-registry trial fortunes-service-registry
-cf create-service p-circuit-breaker-dashboard trial fortunes-circuit-breaker-dashboard

--- a/scripts/pws-undeploy.sh
+++ b/scripts/pws-undeploy.sh
@@ -8,4 +8,3 @@ cf delete fortune-ui -f
 cf delete-service fortunes-db -f
 cf delete-service fortunes-config-server -f
 cf delete-service fortunes-service-registry -f
-cf delete-service fortunes-circuit-breaker-dashboard -f


### PR DESCRIPTION
 - upgrade starters to v3.0.1.RELEASE
 - upgrade spring-boot to v2.1.10.RELEASE
 - upgrade spring-cloud to Greenwich.SR4
 - drop circuit-breaker related config
 - add default fortune since there's no circuit-breaker
 - update README
Connected to pivotal-cf/spring-cloud-services-starters#119